### PR TITLE
Update module path and import statements to reflect new repository structure

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/app"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/config"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/kafka_client"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/schema"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/app"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/config"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/kafka_client"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/schema"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/config"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/logger"
+	"os"
+
+	"github.com/mata-elang-stable/event-stream-aggr/internal/config"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fadhilyori/sensor_events_handler_aggr
+module github.com/mata-elang-stable/event-stream-aggr
 
 go 1.23
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,15 +2,16 @@ package app
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	"github.com/alitto/pond/v2"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/avro"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/protobuf"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/logger"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/pb"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/processor"
-	"sync"
-	"time"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/logger"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/pb"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/processor"
 )
 
 var log = logger.GetLogger()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/logger"
 	"sync"
+
+	"github.com/mata-elang-stable/event-stream-aggr/internal/logger"
 )
 
 type Config struct {

--- a/internal/kafka_client/kafka.go
+++ b/internal/kafka_client/kafka.go
@@ -1,7 +1,7 @@
 package kafka_client
 
 import (
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/logger"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/logger"
 )
 
 var log = logger.GetLogger()

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -3,10 +3,11 @@ package processor
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/logger"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/pb"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/types"
 	"time"
+
+	"github.com/mata-elang-stable/event-stream-aggr/internal/logger"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/pb"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/types"
 )
 
 var log = logger.GetLogger()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -5,8 +5,8 @@ import (
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/avro"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/protobuf"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/logger"
-	"github.com/fadhilyori/sensor_events_handler_aggr/internal/pb"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/logger"
+	"github.com/mata-elang-stable/event-stream-aggr/internal/pb"
 )
 
 var log = logger.GetLogger()


### PR DESCRIPTION
This pull request includes changes to update the module and import paths across multiple files to reflect the new repository name. The most important changes include updating the module name in `go.mod` and modifying import paths in several Go files.

Module and import path updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1): Updated the module name from `github.com/fadhilyori/sensor_events_handler_aggr` to `github.com/mata-elang-stable/event-stream-aggr`.
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L12-R15): Modified import paths to reflect the new repository name.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL5-L9): Changed import paths to reflect the new repository name and reordered imports.
* [`internal/app/app.go`](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R5-R14): Updated import paths to reflect the new repository name and added `sync` and `time` imports.
* `internal/config/config.go`, `internal/kafka_client/kafka.go`, `internal/processor/processor.go`, `internal/schema/schema.go`: Updated import paths to reflect the new repository name. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL4-R6) [[2]](diffhunk://#diff-ec2f54b9e4f1765aa3c315788d871185aff51ec98acdc5e28eb40df5a369a848L4-R4) [[3]](diffhunk://#diff-2beffd8a2ba7a8709c1ec57c621876197093ed74459de9baf4f1732636380e65L6-R10) [[4]](diffhunk://#diff-3c8b74cbf2bd78f25c9f79b06136d5f2553f0877bde14446596a3a538db860dfL8-R9)