### PR TITLE
Add Timestamp field to Snort data structure in GetRawDataFromMetrics function

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -85,6 +85,7 @@ func GetRawDataFromMetrics(data *pb.SensorEvent, metric *pb.Metric) *types.Snort
 		TCPLen:         metric.SnortTcpLen,
 		TCPSeq:         metric.SnortTcpSeq,
 		TCPWin:         metric.SnortTcpWin,
+		Timestamp:      metric.SnortTimestamp,
 		TOS:            data.SnortTypeOfService,
 		TTL:            metric.SnortTimeToLive,
 		UDPLen:         metric.SnortUdpLength,


### PR DESCRIPTION
This pull request includes a small change to the `internal/processor/processor.go` file. The change adds the `Timestamp` field to the `GetRawDataFromMetrics` function to include the `metric.SnortTimestamp` value.

* [`internal/processor/processor.go`](diffhunk://#diff-2beffd8a2ba7a8709c1ec57c621876197093ed74459de9baf4f1732636380e65R88): Added `Timestamp` field to the `GetRawDataFromMetrics` function.